### PR TITLE
NT disable DOCKERFILE linter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM github/super-linter
 COPY rules/ /rules/
 COPY entrypoint.sh /entrypoint.sh
+
+# We only want VALIDATE_DOCKERFILE_HADOLINT, which is enabled by default
+ENV VALIDATE_DOCKERFILE=false
+
 CMD ["chmod", "+x", "/entrypoint.sh"]
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
`DOCKERFILE` and `DOCKERFILE_HADOLINT` sometimes have contradicting results.

Also add a few legal abbreviations (or things that might look like abbreviations).