### PR TITLE
abbreviations

### DIFF
--- a/rules/sun_checks.xml
+++ b/rules/sun_checks.xml
@@ -243,7 +243,7 @@
       <property name="ignoreStatic" value="true"/>
       <property name="ignoreFinal" value="false"/>
       <property name="allowedAbbreviationLength" value="0"/>
-      <property name="allowedAbbreviations" value="IT,ID,XML,DTO,IO,FS,URI" />
+      <property name="allowedAbbreviations" value="AT,IT,ID,XML,DTO,IO,FS,URI,A,I" />
       <property name="tokens"
                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,


### PR DESCRIPTION
The linter's definition of abbreviation is naive at least, e.g.`inAPhrase` with single-letter words there may be no abbreviations but still a sequence of two capitals. Surprisingly, in this phrase it'll be abbreviation `A` to _list as allowed as exemption_, not `AP`. With `A` and `I` being only single-letter words in English I would like to add them to the _list of those allowed despite the general rules_.

OTOH, real abbreviations like URL or XML in my opinion should be discouraged, it's `evenBetterToWriteUrlOrXml`. Maybe apart from AT, IT and DTO, which are traditional and normally describe the class itself, not the concept it represents.

What do you think?

