### PR TITLE
Set duplicate threshold to 10

### DIFF
--- a/rules/.jscpd.json
+++ b/rules/.jscpd.json
@@ -1,5 +1,5 @@
 {
-  "threshold": 0,
+  "threshold": 10,
   "reporters": [
     "consoleFull"
   ],


### PR DESCRIPTION
At the moment we are very strict and all a total of 0% duplicate lines of code, I propose that we just have it at 10 