### PR TITLE
run-locally-script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+superlint
+README.md

--- a/README.md
+++ b/README.md
@@ -116,7 +116,19 @@ Its important to note that you need to mount the `.git` directory and that the p
 /local/path/to/repo/the-a-directory-in-repo/file.txt:/tmp/lint/the-a-directory-in-repo/file.txt
 ```
 
-I am yet to work out how to run against only the diff to master.
+### Well, what if I just want to lint the current changes from the upstream main branch?
+No worries, we've got your back! Add this repo to your path, e.g. for bash users:
+```bash
+# Run this from the directory this README.md is in.
+echo "export PATH=\$PATH:$(pwd)" >> ~/.bashrc
+source ~/.bashrc
+```
+and then run `superlint` from anywhere within a git repository to lint the changes from the remotes HEAD branch!
+By default this will assume the remotes name is `origin`.
+If you wish to target a remote repository with a different name, simply pass in the name as a positional parameter, e.g. for a remote named `upstream`:
+```bash
+superlint upstream
+```
 
 ## Using the Checkstyle rules in Intellij
 While checkstyle is only one of the many linters that are run by this action it, as much of the code we work 

--- a/superlint
+++ b/superlint
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eu
+
+UPSTREAM=${1:origin}
+
+SUPER_LINTER_DIR=$(echo ${BASH_SOURCE[0]} | sed 's/\/superlint//')
+
+echo "rebuilding the super-linter image..."
+docker build -t super-linter $SUPER_LINTER_DIR >/dev/null
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+MAIN_BRANCH=$(git remote show $UPSTREAM | grep "HEAD branch" | sed 's/.*: //')
+MOUNTS="-v ${GIT_ROOT}/.git:/tmp/lint/.git"
+echo "super-linter will lint the following files:"
+for FILE in $(git diff --name-only $MAIN_BRANCH);
+do
+	echo "    ${GIT_ROOT}/${FILE}"
+	MOUNTS="$MOUNTS -v ${GIT_ROOT}/${FILE}:/tmp/lint/${FILE}"
+done
+
+docker run -e LOG_LEVEL=ERROR -e RUN_LOCAL=true $MOUNTS super-linter


### PR DESCRIPTION
Adds a script which makes it easy to run the linter locally. When using this script only the files than have changed from the remote HEAD branch are linted. The target remote repository is optionally configurable, by default it is `origin`.