### PR TITLE
Upgrade super-linter and use slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM github/super-linter:v3.15.1
+FROM github/super-linter:slim-v4.7.3
 COPY rules/ /rules/
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-RUN_LOCAL="${RUN_LOCAL}" 
+RUN_LOCAL="${RUN_LOCAL}"
 
 if [ -z "${RUN_LOCAL}" ]; then
     RUN_LOCAL='false'


### PR DESCRIPTION
The slim image is 2 _gigabytes_ smaller than the regular one (3.59GB vs 5.39GB).

It only excludes linters that we don't care about: https://github.com/github/super-linter#slim-image

Also upgrade to the latest line (v4)