### PR TITLE
Small improvements to superlinter script

### DIFF
--- a/superlint
+++ b/superlint
@@ -78,4 +78,5 @@ else
   done
 fi
 
-docker run -e LOG_LEVEL=ERROR -e RUN_LOCAL=true $MOUNTS super-linter
+echo "--- Running super-linter"
+exec docker run --rm -e LOG_LEVEL=ERROR -e RUN_LOCAL=true $MOUNTS super-linter


### PR DESCRIPTION
1. Echo out when super-linter is actuall running
2. Use `exec` to hand off execution to docker and use its exit-code
3. Use `--rm` to clean up the created container after use
