### PR TITLE
checkstyle: Change javadoc scope property to accessModifiers

### DIFF
--- a/rules/sun_checks.xml
+++ b/rules/sun_checks.xml
@@ -306,7 +306,7 @@
                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>


### PR DESCRIPTION
This was an (accidental?) breaking change in 8.42: https://github.com/checkstyle/checkstyle/issues/7417

Use the new property, and we shouldn't have any problems going forward
