### PR TITLE
Allow multiple empty lines in Gherkin files

### DIFF
--- a/rules/.gherkin-lintrc
+++ b/rules/.gherkin-lintrc
@@ -8,7 +8,7 @@
   "indentation": "off",
   "no-trailing-spaces": "on",
   "new-line-at-eof": ["on", "yes"],
-  "no-multiple-empty-lines": "on",
+  "no-multiple-empty-lines": "off",
   "no-empty-file": "on",
   "no-scenario-outlines-without-examples": "on",
   "name-length": ["on", {"Feature": 80, "Scenario": 140, "Step": 140}],


### PR DESCRIPTION
We've got several codebases with established standards for single empty lines between given/when/then sections and multiple empty lines between scenarios, with the goal of clearer visual separation