### PR TITLE
NT - proposal to deleting gherkin linting rule complaining about any steps not using AND

### DIFF
--- a/rules/.gherkin-lintrc
+++ b/rules/.gherkin-lintrc
@@ -13,7 +13,6 @@
   "no-scenario-outlines-without-examples": "on",
   "name-length": ["on", {"Feature": 80, "Scenario": 140, "Step": 140}],
   "no-restricted-tags": ["on", {"tags": ["@watch", "@wip"]}],
-  "use-and": "on",
   "no-duplicate-tags": "on",
   "no-superfluous-tags": "on",
   "no-homogenous-tags": "on",


### PR DESCRIPTION
Syntactically, it is nice to have some steps using "when" or "then", even if they had originally been defined with an "and".

Please can we turn this off? 