### PR TITLE
Increase the allowed gherkin scenario size a bit

### DIFF
--- a/rules/.gherkin-lintrc
+++ b/rules/.gherkin-lintrc
@@ -20,5 +20,5 @@
   "no-unused-variables": "on",
   "no-background-only-scenario": "off",
   "no-empty-background": "on",
-  "scenario-size": ["on", { "steps-length": {"Background": 15, "Scenario": 30}}]
+  "scenario-size": ["on", { "steps-length": {"Background": 15, "Scenario": 35}}]
 }


### PR DESCRIPTION
The hour of day tests are tripping this, as some of them have a step per hour of day plus the other "regular" steps.