### PR TITLE
Add sqlfluff config

### DIFF
--- a/rules/.sqlfluff
+++ b/rules/.sqlfluff
@@ -1,0 +1,3 @@
+#!cfg
+[sqlfluff]
+dialect = postgres


### PR DESCRIPTION
Currently defaults to 'ansi', which is causing the linter to error.
