### PR TITLE
intellij formatter updates

### DIFF
--- a/ide-config/intellij/Brandwatch.xml
+++ b/ide-config/intellij/Brandwatch.xml
@@ -67,5 +67,9 @@
   </editorconfig>
   <codeStyleSettings language="JAVA">
     <option name="RIGHT_MARGIN" value="140" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+    </indentOptions>
   </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
## Changes
 - Sets `CONTINUATION_INDENT_SIZE` to 4 instead of the default of 8
_interpreting of [Java Code Style Guide - BrandwatchLtd Repositories](https://brandwatch.atlassian.net/wiki/spaces/EH/pages/2920940651/Java+Code+Style+Guide+-+BrandwatchLtd+Repositories) "Brandwatch requires that we always use 4-space indents."_

 - ~enables `ALIGN_MULTILINE_CHAINED_METHODS` which overwrites `CONTINUATION_INDENT_SIZE`~

 - enables `BINARY_OPERATION_SIGN_ON_NEXT_LINE` (aligns with linter action) e.g.
```java
"hello "
    + "world"
```
instead of 
```java
"hello " +
    "world"
```