### PR TITLE
Switch some non-code checks to warnings

### DIFF
--- a/rules/sun_checks.xml
+++ b/rules/sun_checks.xml
@@ -44,6 +44,7 @@
     <property name="fileExtensions" value="java"/>
     <property name="max" value="140"/>
     <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    <property name="severity" value="warning"/>
   </module>
 
   <module name="SuppressWithPlainTextCommentFilter">
@@ -292,14 +293,23 @@
       <property name="allowSamelineMultipleAnnotations" value="true"/>
     </module>
     <module name="NonEmptyAtclauseDescription"/>
-    <module name="InvalidJavadocPosition"/>
-    <module name="JavadocTagContinuationIndentation"/>
+    <module name="InvalidJavadocPosition">
+      <property name="severity" value="warning"/>
+    </module>
+    <module name="JavadocTagContinuationIndentation">
+      <property name="severity" value="warning"/>
+    </module>
     <module name="SummaryJavadoc">
       <property name="forbiddenSummaryFragments"
                value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+      <property name="severity" value="warning"/>
     </module>
-    <module name="JavadocParagraph"/>
-    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    <module name="JavadocParagraph">
+      <property name="severity" value="warning"/>
+    </module>
+    <module name="RequireEmptyLineBeforeBlockTagGroup">
+      <property name="severity" value="warning"/>
+    </module>
     <module name="AtclauseOrder">
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
       <property name="target"
@@ -311,6 +321,7 @@
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+      <property name="severity" value="warning"/>
     </module>
     <module name="MethodName">
       <property name="format" value="^[a-z][a-zA-Z0-9_]*$"/>
@@ -319,6 +330,7 @@
     </module>
     <module name="SingleLineJavadoc">
       <property name="ignoreInlineTags" value="false"/>
+      <property name="severity" value="warning"/>
     </module>
     <module name="EmptyCatchBlock">
       <property name="exceptionVariableName" value="expected"/>


### PR DESCRIPTION
Prevent builds from failing for trivial (IMO) style issues unrelated to code:
* [LineLength](https://checkstyle.sourceforge.io/checks/sizes/linelength.html)
* [InvalidJavadocPosition](https://checkstyle.sourceforge.io/checks/javadoc/invalidjavadocposition.html)
* [JavadocTagContinuationIndentation](https://checkstyle.sourceforge.io/checks/javadoc/javadoctagcontinuationindentation.html)
* [SummaryJavadoc](https://checkstyle.sourceforge.io/checks/javadoc/summaryjavadoc.html)
* [JavadocParagraph](https://checkstyle.sourceforge.io/checks/javadoc/javadocparagraph.html)
* [RequireEmptyLineBeforeBlockTagGroup](https://checkstyle.sourceforge.io/checks/javadoc/requireemptylinebeforeblocktaggroup.html)
* [JavadocMethod](https://checkstyle.sourceforge.io/checks/javadoc/javadocmethod.html)
* [SingleLineJavadoc](https://checkstyle.sourceforge.io/checks/javadoc/singlelinejavadoc.html)