### PR TITLE
Change gherkin step name-length from 180 to 200

### DIFF
--- a/rules/.gherkin-lintrc
+++ b/rules/.gherkin-lintrc
@@ -11,7 +11,7 @@
   "no-multiple-empty-lines": "off",
   "no-empty-file": "on",
   "no-scenario-outlines-without-examples": "on",
-  "name-length": ["on", {"Feature": 80, "Scenario": 140, "Step": 200}],
+  "name-length": ["on", {"Feature": 80, "Scenario": 140, "Step": 240}],
   "no-restricted-tags": ["on", {"tags": ["@watch", "@wip"]}],
   "no-duplicate-tags": "on",
   "no-superfluous-tags": "on",

--- a/rules/.gherkin-lintrc
+++ b/rules/.gherkin-lintrc
@@ -11,7 +11,7 @@
   "no-multiple-empty-lines": "off",
   "no-empty-file": "on",
   "no-scenario-outlines-without-examples": "on",
-  "name-length": ["on", {"Feature": 80, "Scenario": 140, "Step": 180}],
+  "name-length": ["on", {"Feature": 80, "Scenario": 140, "Step": 200}],
   "no-restricted-tags": ["on", {"tags": ["@watch", "@wip"]}],
   "no-duplicate-tags": "on",
   "no-superfluous-tags": "on",


### PR DESCRIPTION
This supports existing long step names like those in [quicksearch](https://github.com/BrandwatchLtd/quicksearch-platform)

I would prefer that lengths be warnings and not errors, but [that is not possible](https://github.com/gherkin-lint/gherkin-lint/issues/21) in the gherkin linter