### PR TITLE
Allow bw-dc-[mini,small,large] runners in github action lint check

### DIFF
--- a/rules/actionlint.yml
+++ b/rules/actionlint.yml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+    - bw-dc-large
+    - bw-dc-small
+    - bw-dc-mini


### PR DESCRIPTION
# Changes

- add rules/actionlint.yml file to accept custom github action runners in lint check.