### PR TITLE
apply indentation rules

### DIFF
--- a/rules/sun_checks.xml
+++ b/rules/sun_checks.xml
@@ -342,8 +342,8 @@
       <property name="basicOffset" value="4"/>
       <property name="braceAdjustment" value="0"/>
       <property name="caseIndent" value="4"/>
-      <property name="throwsIndent" value="8"/>
-      <property name="lineWrappingIndentation" value="8"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="lineWrappingIndentation" value="4"/>
       <property name="arrayInitIndent" value="4"/>
       <property name="forceStrictCondition" value="true"/>
     </module>

--- a/rules/sun_checks.xml
+++ b/rules/sun_checks.xml
@@ -338,6 +338,15 @@
     <module name="CommentsIndentation">
       <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
     </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="braceAdjustment" value="0"/>
+      <property name="caseIndent" value="4"/>
+      <property name="throwsIndent" value="8"/>
+      <property name="lineWrappingIndentation" value="8"/>
+      <property name="arrayInitIndent" value="4"/>
+      <property name="forceStrictCondition" value="true"/>
+    </module>
     <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"


### PR DESCRIPTION
This PR adds new indentation rules enforcing 4sp indentation as default for method args (but also allowing 8sp) and actively blocking inline indentation, which is very difficult to read.

allows single-line methods (within 140 char limit) in line with existing behaviour:

```
public void myMethod(int userId, String userName) {
    return someService.call();
}
```

allows multi-line with 4-space indentation from line start enforced as default (but also allows 8-space):

```
public void myMethod(
        int userId,
        String userName
) {
    return someService.call();
}
```

blocks alignment-based indentation or over 8sp indentation:

```
public void myMethod(int userId,
                     String userName) { 
    return someService.call();
}

public void myMethod(int userId,
                                       String userName) { 
    return someService.call();
}
```