### PR TITLE
fix indentation rules to match IntelliJ defaults

### DIFF
--- a/rules/sun_checks.xml
+++ b/rules/sun_checks.xml
@@ -342,8 +342,8 @@
       <property name="basicOffset" value="4"/>
       <property name="braceAdjustment" value="0"/>
       <property name="caseIndent" value="4"/>
-      <property name="throwsIndent" value="4"/>
-      <property name="lineWrappingIndentation" value="4"/>
+      <property name="throwsIndent" value="8"/>
+      <property name="lineWrappingIndentation" value="8"/>
       <property name="arrayInitIndent" value="4"/>
       <property name="forceStrictCondition" value="true"/>
     </module>


### PR DESCRIPTION
Follow up to https://github.com/BrandwatchLtd/super-linter-action/pull/56

We're seeing thousands of unexpected violations as I got two of the values incorrect and this would require everyone to manually reconfigure their indentation defaults in IntelliJ which is disruptive and not feasible.

By increasing `lineWrappingIndentation` and `throwsIndent` from `4` to `8` we match IntelliJ defaults (there will still be some codebases that will require fixes, but this seems like a more correct approach).

Frustratingly there isn't an OR option so we cannot set 4 OR 8 without a custom implementation.

This is what the rules will enforce, in line with IntelliJ defaults:

```
public class MyClass {              // 0 spaces (class level)
    public void myMethod(           // 4 spaces (method level)
            String param1,          // 12 spaces (4 base + 8 continuation)
            String param2           // 12 spaces
    ) {                             // 4 spaces
        return something;           // 8 spaces (inside method body)
    }
}
```