### PR TITLE
Revert "apply indentation rules"

### DIFF
--- a/rules/sun_checks.xml
+++ b/rules/sun_checks.xml
@@ -338,15 +338,6 @@
     <module name="CommentsIndentation">
       <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
     </module>
-    <module name="Indentation">
-      <property name="basicOffset" value="4"/>
-      <property name="braceAdjustment" value="0"/>
-      <property name="caseIndent" value="4"/>
-      <property name="throwsIndent" value="4"/>
-      <property name="lineWrappingIndentation" value="4"/>
-      <property name="arrayInitIndent" value="4"/>
-      <property name="forceStrictCondition" value="true"/>
-    </module>
     <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"


### PR DESCRIPTION
Reverts BrandwatchLtd/super-linter-action#56

It's sadly causing too many issues and a lot of unexpected side-effects so reverting.

We need something like this, but the `Indentation` module is too restrictive. We likely need a custom rule that can accommodate OR logic or similar.