### PR TITLE
apply indentation rules

### DIFF
--- a/ide-config/intellij/Brandwatch.xml
+++ b/ide-config/intellij/Brandwatch.xml
@@ -67,5 +67,14 @@
   </editorconfig>
   <codeStyleSettings language="JAVA">
     <option name="RIGHT_MARGIN" value="140" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="false" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+    <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+    </indentOptions>
   </codeStyleSettings>
 </code_scheme>

--- a/ide-config/intellij/README.md
+++ b/ide-config/intellij/README.md
@@ -9,4 +9,9 @@ Here you can find .xml for use with IntelliJ, which you can import from `Prefere
 ### Brandwatch.xml Configurations  
 - Brandwatch style import ordering 
 - Right margin set at 140 (superlinter cutoff)
-- some SQL formatting 
+- some SQL formatting
+- Java method signature and parameter formatting:
+  - Blocks inline alignment of multi-line parameters (uses continuation indent instead)
+  - 4-space continuation indent for wrapped parameters (8-space also allowed, but will trigger checkstyle warning)
+  - Closing parenthesis on new line when parameters are wrapped
+  - Applies to both method declarations and method calls 

--- a/rules/sun_checks.xml
+++ b/rules/sun_checks.xml
@@ -338,6 +338,12 @@
     <module name="CommentsIndentation">
       <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
     </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="forceStrictCondition" value="false"/>
+      <property name="severity" value="warning"/>
+    </module>
     <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"


### PR DESCRIPTION
Follow-up to https://github.com/BrandwatchLtd/super-linter-action/pull/56.

This PR adds new indentation formatting and linter rules enforcing a minimum of 4sp indentation as default for method args and actively blocking inline indentation, which is very difficult to read.

Accompanying change in IntelliJ that was needed before I hastily reverted the original change is simple and just need to ensure these are set to 4sp (continuation indent default is 8sp), however unlike the original, reverted change, this is now just a warning so will not fail builds and 8sp can be used.

<img width="337" height="328" alt="IntellIjSettings" src="https://github.com/user-attachments/assets/8f6d30cf-cbe1-4e68-8e5d-dcf54b3f2344" />

This also adds formatting rules to ensure methods with multiline params, have their open/closing parentheses on their own line.

This is the resulting codestyle enforced by these rules:

```
public class MyClass {              // 0 spaces (class level)
    public void myMethod(           // 4 spaces (method level)
        String param1,              // 8 spaces (4 base + 4 continuation)
        String param2               // 8 spaces
    ) {                             // 4 spaces
        return something;           // 8 spaces (inside method body)
    }
}
```
