### PR TITLE
Update .sqlfluff to allow longer lines and ignore linting rules on co…

### DIFF
--- a/rules/.sqlfluff
+++ b/rules/.sqlfluff
@@ -1,3 +1,6 @@
 #!cfg
 [sqlfluff]
 dialect = postgres
+max_line_length = 120
+[sqlfluff:rules:layout.long_lines]
+ignore_comment_lines = true


### PR DESCRIPTION
…mment lines

On Nexus we are using liquidbase to update DB but we are seeing some linting errors with changeset lines being over 80 characters and we can't break up those lines. I feel like comment lines can have any length line and that in general 80 is too short for SQL lines.   I am okay to have one or the other if not both.